### PR TITLE
Removes bulk preloading all existing fonts

### DIFF
--- a/link-rel-preload/fonts/index.html
+++ b/link-rel-preload/fonts/index.html
@@ -4,17 +4,8 @@
     <meta charset="utf-8">
     <title>Web font example</title>
 
-    <link rel="preload" href="fonts/cicle_fina-webfont.eot" as="font" type="application/vnd.ms-fontobject" crossorigin="anonymous">
     <link rel="preload" href="fonts/cicle_fina-webfont.woff2" as="font" type="font/woff2" crossorigin="anonymous">
-    <link rel="preload" href="fonts/cicle_fina-webfont.woff" as="font" type="font/woff" crossorigin="anonymous">
-    <link rel="preload" href="fonts/cicle_fina-webfont.ttf" as="font" type="font/ttf" crossorigin="anonymous">
-    <link rel="preload" href="fonts/cicle_fina-webfont.svg" as="font" type="image/svg+xml" crossorigin="anonymous">
-
-    <link rel="preload" href="fonts/zantroke-webfont.eot" as="font" type="application/vnd.ms-fontobject" crossorigin="anonymous">
     <link rel="preload" href="fonts/zantroke-webfont.woff2" as="font" type="font/woff2" crossorigin="anonymous">
-    <link rel="preload" href="fonts/zantroke-webfont.woff" as="font" type="font/woff" crossorigin="anonymous">
-    <link rel="preload" href="fonts/zantroke-webfont.ttf" as="font" type="font/ttf" crossorigin="anonymous">
-    <link rel="preload" href="fonts/zantroke-webfont.svg" as="font" type="image/svg+xml" crossorigin="anonymous">
 
     <link href="style.css" rel="stylesheet" type="text/css">
   </head>


### PR DESCRIPTION
Because every browser will preload all fonts, even if they don’t need them. This is a very bad example.

[Fixed on MDN too.](https://developer.mozilla.org/en-US/docs/Web/HTML/Preloading_content$revision/1444861)