### PR TITLE
Add missing viewport <meta> tag

### DIFF
--- a/link-rel-preload/media/index.html
+++ b/link-rel-preload/media/index.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Responsive preload example</title>
 
     <link rel="preload" href="bg-image-narrow.png" as="image" media="(max-width: 600px)">


### PR DESCRIPTION
viewport <meta> is required and without it, the media attribute won't work at all. Not only the viewport <meta> is required, but it also has to be put before the media attribute is used because the browser’s preload scanner will not wait for other meta tags to be parsed before evaluating the media query in <link> tags.