### PR TITLE
Fix id for nested comment example

### DIFF
--- a/aria-annotations/index.html
+++ b/aria-annotations/index.html
@@ -104,7 +104,7 @@
 
       <p>The last half of the song is a slow-rising crescendo that peaks at the <mark aria-details="thread-3">end of the guitar solo</mark>, before fading away sharply.</p>
 
-      <div role="comment" id="thread-1" data-author="chris">
+      <div role="comment" id="thread-3" data-author="chris">
         <h3>Chris said</h3>
         <p class="comment-text">I really think this moment could use more cowbell.</p>
         <p><time datetime="2019-03-30T19:29">March 30 2019, 19:29</time></p>


### PR DESCRIPTION
I noticed an error while using this example to test a prototype for annotations support in NVDA.

This looks like a copy / paste error.
The `aria-details` attribute references the element with `id` of `thread-3`.
However, the nested comment element then reuses the `id` of `thread-1`.

This issue prevents the browser from exposing an `aria details` relation for the marked content because there is no element with that `id`.