### PR TITLE
fix custom select's tabindex

### DIFF
--- a/custom-select/index.html
+++ b/custom-select/index.html
@@ -243,7 +243,7 @@
           };
           div.classList.add('select');
           header.classList.add('header');
-          div.tabIndex = 1;
+          div.tabIndex = 0;
           select.tabIndex = -1;
           span.innerText = select.label;
           header.appendChild(span);
@@ -260,7 +260,7 @@
               option.dataset.label = o.label;
               option.onclick = onclick;
               option.onkeyup = onkeyup;
-              option.tabIndex = i + 1;
+              option.tabIndex = 0;
               option.appendChild(label);
               datalist.appendChild(option);
           }


### PR DESCRIPTION
[Example custom select is not available on the keychain #22513](https://github.com/mdn/content/issues/22513)

It is related to the issue in mdn/content.

If the tabindex is not 0, the custom select will not be available on the keychain.