### PR TITLE
Added an example showing SVG dynamic lengths

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,5 @@ The directory contents are as follows:
 * **ARIA annotations**: Examples demonstrating the use of [ARIA annotations](https://wiki.developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Annotations): [See examples live](https://mdn.github.io/html-examples/aria-annotations/) 
 
 * **link-rel-preload**: Examples demonstrating the use of <code>&lt;link rel="preload"&gt;</code>. You can see them live here: [fonts example](https://mdn.github.io/html-examples/link-rel-preload/fonts/) | [video example](https://mdn.github.io/html-examples/link-rel-preload/video/) | [JS and CSS example](https://mdn.github.io/html-examples/link-rel-preload/js-and-css/) | [media example](https://mdn.github.io/html-examples/link-rel-preload/media/)
+
+* **SVG lengths with CSS dynamic units**: Example showing how [CCS dynamic viewport lengths can be used to set the `height` and `width` attributes](https://developer.mozilla.org/en-US/docs/Web/SVG/Element/svg#using_dynamic_viewport_lengths): [See live example](https://mdn.github.io/html-examples/svg-dynamic-lengths)

--- a/svg-dynamic-lengths/index.html
+++ b/svg-dynamic-lengths/index.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <!-- This example is used in https://developer.mozilla.org/en-US/docs/Web/SVG/Element/svg#using_dynamic_viewport_lengths -->
+    <title>wai-aria annotations tests</title>
+    <style>
+      html {
+        font-family: sans-serif;
+      }
+
+      code {
+        font-weight: 700;
+        color: tomato;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>Using dynamic viewport lengths</h1>
+    <p>This example the <code>height</code> and <code>width</code> attributes, on the <code>svg</code> element, are set using the dynamic viewport values <code>vmin</code>. Try resizing the browser to see the svg respond dynamically.</p>
+    <svg viewbox="0 0 500 500" xmlns="http://www.w3.org/2000/svg" height="80vmin" width="80vmin">
+      <rect x="0" y="0" width="50%" height="50%" fill="tomato" opacity="0.75" />
+      <rect x="25%" y="25%" width="50%" height="50%" fill="slategrey" opacity="0.75" />
+      <rect x="50%" y="50%" width="50%" height="50%" fill="olive" opacity="0.75" />
+      <rect x="0" y="0" width="100%" height="100%" stroke="cadetblue" stroke-width="0.5%" fill="none" />
+    </svg>
+
+  </body>
+</html>


### PR DESCRIPTION
I have added an example of setting the `height` and `width` attributes on an `svg` element that can be linked to from the [`svg` element page](https://developer.mozilla.org/en-US/docs/Web/SVG/Element/svg), so that the user can see the effect of resizing the browser.

I have done this as I am working on documenting this [issue](https://github.com/mdn/content/issues/29308) and this [bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1287054).